### PR TITLE
Use gsl from the system, via pkg-config when available.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2024-03-25  Tomas Kalibera  <tomas.kalibera@gmail.com>
+
+	* src/Makevars.ucrt: Use gsl from Rtools >= 42
+
 2025-03-23  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll micro version and date

--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -1,2 +1,9 @@
-CRT=-ucrt
-include Makevars.win
+ifeq (,$(shell pkg-config --version 2>/dev/null))
+  PKG_LIBS = -lgsl -lgslcblas -lm
+else
+  PKG_CPPFLAGS = $(shell pkg-config --cflags gsl)
+  PKG_LIBS = $(shell pkg-config --libs gsl)
+endif
+
+PKG_CPPFLAGS += -I../inst/include
+


### PR DESCRIPTION
This patch switches to using gsl from the system, when available via pkg-config or otherwise using hard-coded library dependencies. It makes the package work with gsl from Rtools42-45. Behavior with previous versions of R is not affected, as this uses the .ucrt version of Makevars.

This silences a warning (now on CRAN results) about using non-allowed external symbols.
